### PR TITLE
fix for files with utf-8 encoding

### DIFF
--- a/lazyjson.py
+++ b/lazyjson.py
@@ -148,7 +148,7 @@ class File(BaseFile):
         super().__init__()
         self.openargs = {}
         for key in kwargs:
-            if key in ("buffering", "mode", "errors", "newline", "closefd", "opener"):
+            if key in ("buffering", "errors", "newline", "closefd", "opener"):
                 self.openargs[key] = kwargs[key]
         self.encoding = encoding
         self.file_is_open = isinstance(file_info, io.IOBase) if file_is_open is None else bool(file_is_open)


### PR DESCRIPTION
I've solved the problem mentioned in issue #2 .
If we set the file path and the encoding for the File class's ctor then its working fine. Also when I used the codecs.open with the correct encoding it always failed.
